### PR TITLE
Allow Showable to be nested to allow multiple output types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,19 @@ false
 julia> showable("text/markdown", md_as_md)
 true
 ```
+
+It is also possible to use nesting in order to allow the object to be displayed
+as multiple MIME types:
+
+```julia
+julia> md_as_html_or_text = Markdown.parse("hello") |> DisplayAs.HTML |> DisplayAs.Text;
+
+julia> showable("text/html", md_as_html_or_text)
+true
+
+julia> showable("text/plain", md_as_html_or_text)
+true
+
+julia> showable("text/markdown", md_as_html_or_text)
+false
+```

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,10 @@ using Test
     @test showable("text/html", DisplayAs.HTML(nothing))
     @test showable("text/markdown", DisplayAs.MD(nothing))
     @test showable("image/png", DisplayAs.PNG(nothing))
+    text_png = DisplayAs.Text(DisplayAs.PNG(nothing))
+    @test showable("text/plain", text_png)
+    @test showable("image/png", text_png)
+    @test !showable("image/html", text_png)
 end
 
 using Aqua


### PR DESCRIPTION
I will close https://github.com/fredrikekre/Literate.jl/issues/61 with a note about using `DisplayAs`, but would be nice to be able to allow multiple outputs, such that you can limit output to e.g. `text/plain` and `image/png`, while filtering out `image/svg` etc.