### PR TITLE
Rename: `Unlimited(x)` -> `unlimited(x)`

### DIFF
--- a/src/DisplayAs.jl
+++ b/src/DisplayAs.jl
@@ -206,9 +206,12 @@ julia> data = dataset("cars");
 julia> data |> DisplayAs.unlimited
 ```
 """
-unlimited(x) =
-    setcontext(x, :compact => false, :limit => false,
-                  :displaysize => (typemax(Int), typemax(Int)))
+unlimited(x) = setcontext(
+    x,
+    :compact => false,
+    :limit => false,
+    :displaysize => (typemax(Int), typemax(Int)),
+)
 
 @deprecate Unlimited(x) unlimited(x) false
 

--- a/src/DisplayAs.jl
+++ b/src/DisplayAs.jl
@@ -192,9 +192,9 @@ for mime in _textmimes
 end
 
 """
-    Unlimited
+    DisplayAs.unlimited(x)
 
-Unlimit display size. Useful for, e.g., printing all contents of
+Unlimit display size of object `x`. Useful for, e.g., printing all contents of
 dataframes in a Jupyter notebook.
 
 # Examples
@@ -203,13 +203,14 @@ julia> using DisplayAs, VegaDatasets
 
 julia> data = dataset("cars");
 
-julia> data |> DisplayAs.Unlimited
+julia> data |> DisplayAs.unlimited
 ```
 """
-function Unlimited(x)
+unlimited(x) =
     setcontext(x, :compact => false, :limit => false,
                   :displaysize => (typemax(Int), typemax(Int)))
-end
+
+@deprecate Unlimited(x) unlimited(x) false
 
 include("Raw.jl")
 


### PR DESCRIPTION
As `Unlimited` is not a type anymore, deprecate it in favor of the factory function `unlimited`.